### PR TITLE
Fixing undeclared variable _db in sync

### DIFF
--- a/lib/backbone.couchdb.js
+++ b/lib/backbone.couchdb.js
@@ -94,8 +94,8 @@
     sync: function(method, model, cb) {
       // XXX - This is going to be a memory issue unless someone does the
       // extend trick.
-      _db = this._db || (this.collection && this.collection._db);
-      if (!_db) this._db = Backbone.couch.db(
+      var _db = this._db || (this.collection && this.collection._db);
+      if (!_db) _db = this._db = Backbone.couch.db(
         Backbone.couch.options.database);
       var type = 'model' in model ? 'collection' : 'model';
       couch[type][method](_db, model, cb);


### PR DESCRIPTION
I spotted to bugs in `sync`:
1. The variable `_db` isn't declared anywhere, thus becoming a property of the global scope
2. If there isn't any `_db` associated with a model (or it's collection), there is one created and saved to the model's `_db` property. But the variable `_id` isn't updated.
